### PR TITLE
Fix: Update Vite config for GitHub Pages deployment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,6 +22,6 @@ export default defineConfig(({ mode }) => {
       port: 8080,
       open: true
     },
-    base: './'
+    base: isProduction ? '/randos/' : './'
   };
 });


### PR DESCRIPTION
Set the base path to '/randos/' in vite.config.ts for production builds to ensure assets are loaded correctly when deployed to GitHub Pages.