### PR TITLE
Fix: Update Node.js to v22 in GitHub Actions workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '22'
         cache: 'npm'
         
     - name: Install dependencies


### PR DESCRIPTION
This change updates the Node.js version used in the GitHub Actions workflow from v18 to v22 as per user request.

The Vite build process was failing with the error: `[vite:build-html] crypto.hash is not a function`

Updating to a more recent version of Node.js (v22) should provide the necessary crypto functionalities that Vite 7 relies upon, resolving the build failure during the HTML processing stage.