### PR TITLE
Fix: Update GitHub Pages deployment workflow and add deployment.md

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,3 +34,5 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./dist
+        disable_jekyll: true
+        force_orphan: true

--- a/deployment.md
+++ b/deployment.md
@@ -1,0 +1,14 @@
+# Deployment Documentation
+
+This file documents the deployment process for this project.
+
+The project is automatically deployed to GitHub Pages when changes are pushed to the `main` branch.
+
+The GitHub Actions workflow `.github/workflows/deploy.yml` handles the build and deployment.
+
+Key settings:
+- Node.js version: 22
+- Build command: `npm run build:prod`
+- Publish directory: `./dist`
+- Target branch: `gh-pages`
+- Jekyll is disabled for the Pages site.


### PR DESCRIPTION
- Modify the GitHub Actions workflow to include `disable_jekyll: true` and `force_orphan: true` for the GitHub Pages deployment step.
- Add `deployment.md` to document the deployment process and to provide a change to trigger the workflow.