### PR TITLE
Implement player-by-player shopping phase at end of round

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -22,7 +22,7 @@ export class BattleArenaGame {
     private roundTimer: Phaser.Time.TimerEvent | null = null;
     private roundDuration: number = 30000; // 30 seconds in milliseconds
     private remainingTime: number = 0; // Added to store remaining time
-    private readyPlayers: Set<string> = new Set(); // Set to store IDs of players who are ready
+    // private readyPlayers: Set<string> = new Set(); // Set to store IDs of players who are ready - No longer needed for this flow
 
     constructor(playerCount: number, updateCallback: (playersAlive: number, gameState: GameState, roundNumber: number, remainingTime: number) => void, gameEndCallback: (winner: string) => void) {
         this.updateCallback = updateCallback;
@@ -96,24 +96,15 @@ export class BattleArenaGame {
     }
 
     public nextRound(): void {
-        if (this.currentGameState === GameState.RoundOver || this.currentGameState === GameState.Shop) {
-            // Check if all remaining players are ready
-            const alivePlayerIds = this.gameScene.getAlivePlayers().map(p => p.id);
-            const allReady = alivePlayerIds.every(id => this.readyPlayers.has(id));
-
-            if (allReady || alivePlayerIds.length === 0) { // Proceed if all alive players are ready or no one is left to ready up
-                this.currentRound++;
-                this.setCurrentGameState(GameState.Playing);
-                this.gameScene.resetRound();
-                this.startRoundTimer();
-                this.readyPlayers.clear(); // Clear ready status for the new round
-                this.updateCallback(this.gameScene.getAlivePlayersCount(), this.currentGameState, this.currentRound, this.getRemainingTime());
-            } else {
-                // Notify UI that not all players are ready
-                console.log("Waiting for all players to ready up...");
-                // This message should ideally be shown in the game UI
-                this.updateCallback(this.gameScene.getAlivePlayersCount(), GameState.Shop, this.currentRound, this.getRemainingTime()); // Remain in shop/round over state
-            }
+        // Player readiness is now handled by the GameController's shopping turn logic.
+        // This function is called when the "Next Round" button is clicked after all players have shopped.
+        if (this.currentGameState === GameState.Shop || this.currentGameState === GameState.RoundOver) {
+            this.currentRound++;
+            this.setCurrentGameState(GameState.Playing);
+            this.gameScene.resetRound();
+            this.startRoundTimer();
+            // No need to clear readyPlayers here as it's no longer used for this flow.
+            this.updateCallback(this.gameScene.getAlivePlayersCount(), this.currentGameState, this.currentRound, this.getRemainingTime());
         }
     }
 
@@ -130,14 +121,15 @@ export class BattleArenaGame {
         return 0;
     }
 
-    public playerReady(playerId: string): void {
-        if (this.currentGameState === GameState.RoundOver || this.currentGameState === GameState.Shop) {
-            this.readyPlayers.add(playerId);
-            console.log(`${playerId} is ready.`);
-            // Optionally, attempt to start next round if all are now ready
-            this.nextRound();
-        }
-    }
+    // playerReady is no longer needed as the shopping phase completion gates the next round.
+    // public playerReady(playerId: string): void {
+    //     if (this.currentGameState === GameState.RoundOver || this.currentGameState === GameState.Shop) {
+    //         this.readyPlayers.add(playerId);
+    //         console.log(`${playerId} is ready.`);
+    //         // Optionally, attempt to start next round if all are now ready
+    //         this.nextRound();
+    //     }
+    // }
 
     private startRoundTimer(): void {
         if (this.roundTimer) {

--- a/src/index.html
+++ b/src/index.html
@@ -219,10 +219,11 @@
     <div id="gameContainer"></div>
 
     <div id="shopOverlay" class="hidden">
-        <h2>Shop</h2>
+        <h2 id="shopTitle">Shop</h2> <!-- Added id for dynamic title -->
         <div id="shopItems"></div>
         <div id="playerGoldDisplay">Player Gold: 0</div>
-        <p>Click "Next Round" (in game controls) when done shopping.</p>
+        <button id="finishShoppingButton">Finish Shopping</button> <!-- Added Finish Shopping button -->
+        <!-- Removed the "Next Round" message as it's now handled by Finish Shopping button -->
     </div>
 
     <script type="module" src="./main.ts"></script>


### PR DESCRIPTION
- Modified GameController to manage individual shopping turns for each alive player.
- Added a 'Finish Shopping' button in the shop UI to progress to the next player or conclude the shopping phase.
- Updated BattleArenaGame to remove old player readiness logic, as starting the next round is now gated by all players completing their shopping.
- Adjusted UI elements and their visibility to support the new shopping flow, ensuring the 'Next Round' button appears only after shopping is complete or if the shop is skipped.